### PR TITLE
ポスター表示箇所をコメントアウトしました

### DIFF
--- a/components/organisms/PosterDownload.vue
+++ b/components/organisms/PosterDownload.vue
@@ -1,12 +1,12 @@
 <template lang="pug">
   .posterDownload#poster
     SectionTitle(:title="'Poster'")
-    .container
-      .main_wrapper
-        a(href="./../download/oic2020_poster.pdf" target="__blank").download_image_wrapper
-          img(src="~/assets/images/oic2020_poster.png").download_image
-        .download_discription コチラのオンコンのポスターをダウンロードすることができます。
-        a.download_btn(href="./../download/oic2020_poster.pdf" target="__blank") 別ページでPDFを開く
+    .container Coming soon
+      //- .main_wrapper
+      //-   a(href="./../download/oic2020_poster.pdf" target="__blank").download_image_wrapper
+      //-     img(src="~/assets/images/oic2020_poster.png").download_image
+      //-   .download_discription コチラのオンコンのポスターをダウンロードすることができます。
+      //-   a.download_btn(href="./../download/oic2020_poster.pdf" target="__blank") 別ページでPDFを開く
 </template>
 <script>
 import SectionTitle from '~/components/atoms/SectionTitle.vue'

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -17,7 +17,7 @@
               .member_role(v-if="mem.role") {{mem.role}}
               img.member_icon(v-if="mem.icon" :src="require(`~/assets/member_imgs/${mem.icon}.png`)")
               .member_name {{mem.name}}
-    PosterDownload
+    //- PosterDownload
     Footer
 </template>
 <script>


### PR DESCRIPTION
@tussi5969 
ポスター表示箇所をコメントアウトしただけです．
ここに来て，まとめてプルリクするべきだったと気付きました．
branch名を特定のものにしてしまったため，この対応を取りました．
お手数おかけします．
![スクリーンショット 2020-04-07 0 24 00](https://user-images.githubusercontent.com/39401550/78575862-e14ae280-7866-11ea-93b5-48dcaf9cb9f5.png)

